### PR TITLE
Encoding in Buffer on index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function toFile(input) {
 		return resolve(data ? {
 			mimeType: data[2],
 			encoding: data[3],
-			data: new Buffer(data[4]),
+			data: new Buffer(data[4], encoding),
 			extension: _mime2.default.extension(data[2])
 		} : undefined);
 	});


### PR DESCRIPTION
Default encoding is UTF-8 but in some cases the file is corrupt because it is base64.
