### PR TITLE
Added base64 decoding to data buffer init

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function toFile(input) {
 		return resolve(data ? {
 			mimeType: data[2],
 			encoding: data[3],
-			data: new Buffer(data[4]),
+			data: new Buffer(data[4], 'base64'),
 			extension: mime.extension(data[2])
 		} : undefined);
 	});


### PR DESCRIPTION
Added base64 decoding to data buffer init. Now returns binary buffer instead of base64-encoded string one. Does it make any sense?